### PR TITLE
Tons of InputManager fixes and features - closes #11 & closes #12

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -7,8 +7,9 @@ define([
   './utils/degreesFromCenter',
   './utils/radiansFromCenter',
   './utils/scalePoints',
-  './utils/translatePoints'
-], function(averagePoints, degreesToRadians, radiansToDegrees, pointInPolygon, distance, degreesFromCenter, radiansFromCenter, scalePoints, translatePoints){
+  './utils/translatePoints',
+  './utils/insideCanvas'
+], function(averagePoints, degreesToRadians, radiansToDegrees, pointInPolygon, distance, degreesFromCenter, radiansFromCenter, scalePoints, translatePoints, insideCanvas){
 
   'use strict';
 
@@ -103,6 +104,16 @@ define([
       * @param {Object} offset Object with an x and y value
       *
     */
-    translatePoints: translatePoints
+    translatePoints: translatePoints,
+
+    /**
+     * Check whether a point is inside a canvas
+     * @name utils#insideCanvas
+     * @function
+     * @param {Object} point A point to test
+     * @param {Object} canvas Object with height and width properties
+     * @return {Boolean} True if inside canvas else false
+     */
+    insideCanvas: insideCanvas
   };
 });

--- a/src/utils/insideCanvas.js
+++ b/src/utils/insideCanvas.js
@@ -1,0 +1,15 @@
+define(function(){
+
+  'use strict';
+
+  function insideCanvas(pt, canvas){
+    if((pt.x < 0) || (pt.x >  canvas.width) || (pt.y < 0) || (pt.y > canvas.height)){
+      return false;
+    } else {
+      return true;
+    }
+  }
+
+  return insideCanvas;
+
+});


### PR DESCRIPTION
implement insideCanvas utility and flag on inputManager gameActions - closes #11, null out endPosition on mouseDown or touchStart, set startPosition, pressed and position only if point is insideCanvas else null out startPosition, fix bug in touchMove referencing mouseAction and not using changedTouches, call e.preventDefault in touchMove only if a startPosition was registered
