### PR TITLE
add default lineWidth to Entity - closes #18

### DIFF
--- a/src/box2d/CircleEntity.js
+++ b/src/box2d/CircleEntity.js
@@ -25,6 +25,8 @@ define([
     draw: dcl.superCall(function(sup){
       return function(ctx, scale){
         scale = scale || this.scale || 1;
+        var ogLineWidth = ctx.lineWidth;
+        ctx.lineWidth = this.lineWidth;
         ctx.fillStyle = this.color;
         ctx.strokeStyle = this.strokeColor;
         ctx.beginPath();
@@ -45,6 +47,7 @@ define([
           ctx.stroke();
           ctx.restore();
         }
+        ctx.lineWidth = ogLineWidth;
         sup.apply(this, [ctx, scale]);
       };
     }),

--- a/src/box2d/Entity.js
+++ b/src/box2d/Entity.js
@@ -29,6 +29,7 @@ define([
     staticBody: false,
     color: 'rgba(128,128,128,0.5)',
     strokeColor: '#000',
+    lineWidth: 1,
     hidden: false,
     /* Used for collision filtering */
     maskBits: null,
@@ -48,6 +49,8 @@ define([
     */
     draw: function(ctx, scale){
       scale = scale || this.scale || 1;
+      var ogLineWidth = ctx.lineWidth;
+      ctx.lineWidth = this.lineWidth;
       // black circle in entity's location
       ctx.fillStyle = this.strokeColor;
       ctx.beginPath();
@@ -63,6 +66,8 @@ define([
         ctx.closePath();
         ctx.fill();
       }
+
+      ctx.lineWidth = ogLineWidth;
     },
 
     /**

--- a/src/box2d/MultiPolygonEntity.js
+++ b/src/box2d/MultiPolygonEntity.js
@@ -30,6 +30,8 @@ define([
     draw: dcl.superCall(function(sup){
       return function(ctx, scale){
         scale = scale || this.scale || 1;
+        var ogLineWidth = ctx.lineWidth;
+        ctx.lineWidth = this.lineWidth;
         ctx.save();
         ctx.translate(this.x * scale, this.y * scale);
         ctx.rotate(this.angle);
@@ -50,6 +52,7 @@ define([
         }
 
         ctx.restore();
+        ctx.lineWidth = ogLineWidth;
         sup.apply(this, [ctx, scale]);
       };
     }),

--- a/src/box2d/PolygonEntity.js
+++ b/src/box2d/PolygonEntity.js
@@ -21,6 +21,8 @@ define([
     draw: dcl.superCall(function(sup){
       return function(ctx, scale){
         scale = scale || this.scale || 1;
+        var ogLineWidth = ctx.lineWidth;
+        ctx.lineWidth = this.lineWidth;
         ctx.save();
         ctx.translate(this.x * scale, this.y * scale);
         ctx.rotate(this.angle);
@@ -39,6 +41,7 @@ define([
         ctx.stroke();
 
         ctx.restore();
+        ctx.lineWidth = ogLineWidth;
         sup.apply(this, [ctx, scale]);
       };
     }),

--- a/src/box2d/RectangleEntity.js
+++ b/src/box2d/RectangleEntity.js
@@ -20,6 +20,8 @@ define([
     draw: dcl.superCall(function(sup){
       return function(ctx, scale){
         scale = scale || this.scale || 1;
+        var ogLineWidth = ctx.lineWidth;
+        ctx.lineWidth = this.lineWidth;
         ctx.save();
         ctx.translate(this.x * scale, this.y * scale);
         ctx.rotate(this.angle);
@@ -39,6 +41,7 @@ define([
           (this.halfHeight*2) * scale
         );
         ctx.restore();
+        ctx.lineWidth = ogLineWidth;
         sup.apply(this, [ctx, scale]);
       };
     }),


### PR DESCRIPTION
use this.lineWidth in default draw for each entity type and reset to original lineWidth when finished
