### PR TITLE
Fixed lodash dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
       "util": "github:dojo/util/1.8.3",
       "dcl": "github:uhop/dcl/1.0.2",
       "Box2d.min": "https://box2dweb.googlecode.com/svn/trunk/Box2d.min.js",
-      "lodash": "github:bestiejs/lodash/v1.3.1",
+      "lodash": "github:lodash/lodash/1.3.1",
       "hammer/hammer": "github:phated/hammer.js/frozen"
     }
   },


### PR DESCRIPTION
The URL for lodash has changed, causing dependency issues on install.
